### PR TITLE
Replaced SimpleView with ContiguousView

### DIFF
--- a/mathoxide-lib/src/array.rs
+++ b/mathoxide-lib/src/array.rs
@@ -4,8 +4,7 @@ use num_traits::Num;
 
 use crate::formatter::{ArrayFormatter, VerboseFormatter};
 use crate::storage::Storage;
-use crate::views;
-use crate::views::ArrayView;
+use crate::views::{ArrayView, ContiguousView};
 
 pub struct Array<StorageType, ViewType> {
     storage: StorageType,
@@ -32,32 +31,44 @@ where
     StorageType: Storage<Stored = T>,
     ViewType: ArrayView,
 {
-    pub fn offset(&self) -> usize {
+    pub fn storage_offset(&self) -> usize {
         self.view.offset()
-    }
-
-    pub fn ndims(&self) -> usize {
-        self.view.ndims()
-    }
-
-    pub fn size(&self) -> usize {
-        self.view.size()
     }
 
     pub fn shape(&self) -> &[usize] {
         self.view.shape()
     }
+
+    pub fn stride(&self) -> &[usize] {
+        self.view.stride()
+    }
+
+    pub fn ndim(&self) -> usize {
+        self.view.ndim()
+    }
+
+    pub fn numel(&self) -> usize {
+        self.view.numel()
+    }
+
+    pub fn is_contiguous(&self) -> bool {
+        self.view.is_contiguous()
+    }
+
+    pub fn storage_size(&self) -> usize {
+        self.storage.storage_get().iter().len()
+    }
 }
 
-impl<T, StorageType> Array<StorageType, views::SimpleView>
+impl<T, StorageType> Array<StorageType, ContiguousView>
 where
     T: Num,
     StorageType: Storage<Stored = T>,
 {
     pub fn zeros<ListType: AsRef<[usize]>>(shape: ListType) -> Self {
-        let view = views::SimpleView::new(shape);
+        let view = ContiguousView::new(shape);
         let mut v = Vec::new();
-        v.resize_with(view.size(), T::zero);
+        v.resize_with(view.numel(), T::zero);
         let storage = StorageType::from(v);
         Array { storage, view }
     }
@@ -70,7 +81,7 @@ mod test {
 
     #[test]
     fn check_2d_nrows_format() {
-        let array = Array::<ThreadSafeStorage<u32>, views::SimpleView>::zeros(&[4, 5]);
+        let array = Array::<ThreadSafeStorage<u32>, ContiguousView>::zeros(&[4, 5]);
         let formatted = array.to_string();
         assert_eq!(formatted.split('\n').count(), array.shape()[0]);
     }

--- a/mathoxide-lib/src/array.rs
+++ b/mathoxide-lib/src/array.rs
@@ -56,7 +56,7 @@ where
     }
 
     pub fn storage_size(&self) -> usize {
-        self.storage.storage_get().iter().len()
+        self.storage.storage_len().expect("Cannot get array length")
     }
 }
 

--- a/mathoxide-lib/src/formatter.rs
+++ b/mathoxide-lib/src/formatter.rs
@@ -28,7 +28,7 @@ impl<'a, T: Num + fmt::Display, ViewType: ArrayView> ArrayFormatter
     for VerboseFormatter<'a, T, ViewType>
 {
     fn format(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.view.ndims() {
+        match self.view.ndim() {
             2 => {
                 let mut s = String::new();
                 let nrows = self.view.shape()[0];

--- a/mathoxide-lib/src/lib.rs
+++ b/mathoxide-lib/src/lib.rs
@@ -6,4 +6,5 @@ mod formatter;
 mod storage;
 mod thread_safe_storage;
 mod thread_unsafe_storage;
+mod view_iters;
 mod views;

--- a/mathoxide-lib/src/view_iters.rs
+++ b/mathoxide-lib/src/view_iters.rs
@@ -1,0 +1,25 @@
+pub struct ContiguousViewIterator {
+    curr: usize,
+    end: usize,
+}
+
+impl ContiguousViewIterator {
+    pub fn new(curr: usize, end: usize) -> Self {
+        Self { curr, end }
+    }
+}
+
+impl Iterator for ContiguousViewIterator {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let curr = self.curr;
+        self.curr += 1;
+
+        if curr < self.end {
+            Some(curr)
+        } else {
+            None
+        }
+    }
+}

--- a/mathoxide-lib/src/views.rs
+++ b/mathoxide-lib/src/views.rs
@@ -82,7 +82,7 @@ impl ArrayView for ContiguousView {
     }
 
     fn translate_iter(&self) -> Self::IterType {
-        let begin = self.translate(vec![0; self.ndim()]);
+        let begin = self.offset();
         let end = begin + self.numel();
         ContiguousViewIterator::new(begin, end)
     }

--- a/mathoxide-lib/src/views.rs
+++ b/mathoxide-lib/src/views.rs
@@ -38,7 +38,7 @@ impl ContiguousView {
             .rev()
             .scan(1, |state, &x| {
                 let tmp = *state;
-                *state = *state * x;
+                *state *= x;
                 Some(tmp)
             })
             .collect::<Vec<usize>>();
@@ -88,7 +88,10 @@ mod test {
     fn contiguous_view_check_last_item() {
         let view = ContiguousView::new([2, 3, 4]);
         assert_eq!(view.translate([1, 2, 3]), view.numel() - 1);
+    }
 
+    #[test]
+    fn contiguous_view_offset_check_last_item() {
         let offset: usize = 5;
         let view = ContiguousView::new_with_offset([2, 3, 4], offset);
         assert_eq!(view.translate([1, 2, 3]), view.numel() - 1 + offset);

--- a/mathoxide-lib/src/views.rs
+++ b/mathoxide-lib/src/views.rs
@@ -1,47 +1,77 @@
 pub trait ArrayView {
     fn translate<ListType: AsRef<[usize]>>(&self, idx: ListType) -> usize;
     fn offset(&self) -> usize;
-    fn ndims(&self) -> usize;
-    fn size(&self) -> usize;
     fn shape(&self) -> &[usize];
+    fn stride(&self) -> &[usize];
+    fn ndim(&self) -> usize {
+        self.shape().len()
+    }
+    fn numel(&self) -> usize {
+        self.shape().iter().product()
+    }
+    fn is_contiguous(&self) -> bool;
 }
 
-pub struct SimpleView {
+pub struct ContiguousView {
     shape: Vec<usize>,
+    offset: usize,
+    stride: Vec<usize>,
 }
 
-impl SimpleView {
+impl ContiguousView {
     pub fn new<ListType: AsRef<[usize]>>(shape: ListType) -> Self {
+        Self::new_with_offset(shape, 0)
+    }
+
+    pub fn new_with_offset<ListType: AsRef<[usize]>>(shape: ListType, offset: usize) -> Self {
         Self {
             shape: shape.as_ref().to_vec(),
+            offset,
+            stride: Self::compute_stride(shape.as_ref()),
         }
+    }
+
+    fn compute_stride<ListType: AsRef<[usize]>>(shape: ListType) -> Vec<usize> {
+        let mut res = shape
+            .as_ref()
+            .iter()
+            .rev()
+            .scan(1, |state, &x| {
+                let tmp = *state;
+                *state = *state * x;
+                Some(tmp)
+            })
+            .collect::<Vec<usize>>();
+        res.reverse();
+        res
     }
 }
 
-impl ArrayView for SimpleView {
+impl ArrayView for ContiguousView {
     fn translate<ListType: AsRef<[usize]>>(&self, idx: ListType) -> usize {
-        let mut res: usize = 0;
-        for (idx_i, shape_i) in idx.as_ref().iter().zip(self.shape.iter()) {
-            res *= shape_i;
-            res += idx_i;
-        }
-        res
+        self.offset()
+            + idx
+                .as_ref()
+                .iter()
+                .zip(self.stride().iter())
+                .map(|(x, y)| x * y)
+                .sum::<usize>()
     }
 
     fn offset(&self) -> usize {
-        0
-    }
-
-    fn ndims(&self) -> usize {
-        self.shape.len()
-    }
-
-    fn size(&self) -> usize {
-        self.shape.iter().product()
+        self.offset
     }
 
     fn shape(&self) -> &[usize] {
         self.shape.as_slice()
+    }
+
+    fn stride(&self) -> &[usize] {
+        self.stride.as_slice()
+    }
+
+    fn is_contiguous(&self) -> bool {
+        true
     }
 }
 
@@ -50,14 +80,23 @@ mod test {
     use super::*;
 
     #[test]
-    fn simple_view_check_last_item() {
-        let view = SimpleView::new([2, 3, 4]);
-        assert_eq!(view.translate([1, 2, 3]), view.size() - 1);
+    fn contiguous_view_check() {
+        assert_eq!(ContiguousView::new([2, 3]).is_contiguous(), true);
     }
 
     #[test]
-    fn simple_view_translate() {
-        let view = SimpleView::new([2, 3, 4]);
+    fn contiguous_view_check_last_item() {
+        let view = ContiguousView::new([2, 3, 4]);
+        assert_eq!(view.translate([1, 2, 3]), view.numel() - 1);
+
+        let offset: usize = 5;
+        let view = ContiguousView::new_with_offset([2, 3, 4], offset);
+        assert_eq!(view.translate([1, 2, 3]), view.numel() - 1 + offset);
+    }
+
+    #[test]
+    fn contiguous_view_translate() {
+        let view = ContiguousView::new([2, 3, 4]);
         let mut counter = 0;
         for i in 0..2 {
             for j in 0..3 {
@@ -70,9 +109,9 @@ mod test {
     }
 
     #[test]
-    fn simple_view_ndims() {
-        assert_eq!(SimpleView::new([2]).ndims(), 1);
-        assert_eq!(SimpleView::new([2, 3]).ndims(), 2);
-        assert_eq!(SimpleView::new([2, 3, 4]).ndims(), 3);
+    fn contiguous_view_ndims() {
+        assert_eq!(ContiguousView::new([2]).ndim(), 1);
+        assert_eq!(ContiguousView::new([2, 3]).ndim(), 2);
+        assert_eq!(ContiguousView::new([2, 3, 4]).ndim(), 3);
     }
 }


### PR DESCRIPTION
This PR completes issue #3 

TODO:

- [x] Add method to view that returns iterator of storage indices (more optimized than multiple `translate()` calls)