### PR TITLE
Implemented reshape

### DIFF
--- a/mathoxide-lib/src/array.rs
+++ b/mathoxide-lib/src/array.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use num_traits::Num;
 
 use crate::formatter::{ArrayFormatter, VerboseFormatter};
+use crate::shape_utils::{self, ShapeDim};
 use crate::storage::Storage;
 use crate::views::{ArrayView, ContiguousView};
 
@@ -72,6 +73,27 @@ where
         let storage = StorageType::from(v);
         Array { storage, view }
     }
+
+    pub fn reshape<SizeType, ListType>(&self, shape: ListType) -> Self
+    where
+        SizeType: Copy,
+        ShapeDim: From<SizeType>,
+        ListType: AsRef<[SizeType]>,
+    {
+        let new_shape = shape_utils::infer_shape(shape, self.numel());
+        if new_shape.iter().product::<usize>() != self.numel() {
+            panic!(
+                "{:?} not a valid shape for array of size {}",
+                new_shape,
+                self.numel()
+            );
+        }
+        let view = ContiguousView::new_with_offset(new_shape, self.storage_offset());
+        Array {
+            storage: self.storage.clone(),
+            view,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -84,5 +106,25 @@ mod test {
         let array = Array::<ThreadSafeStorage<u32>, ContiguousView>::zeros(&[4, 5]);
         let formatted = array.to_string();
         assert_eq!(formatted.split('\n').count(), array.shape()[0]);
+    }
+
+    #[test]
+    fn reshape_2d_to_1d() {
+        let array = Array::<ThreadSafeStorage<u32>, ContiguousView>::zeros(&[2, 3]);
+        // Temporary until getters for Array are available
+        println!("{}", array);
+        let row_vec = array.reshape([6usize]);
+        println!("{}", row_vec);
+    }
+
+    #[test]
+    fn reshape_2d_to_1d_inferred() {
+        let array = Array::<ThreadSafeStorage<u32>, ContiguousView>::zeros(&[2, 3]);
+        // Temporary until getters for Array are available
+        println!("{}", array);
+        let row_vec = array.reshape([-1isize]);
+        println!("{}", row_vec);
+        let col_vec = array.reshape([-1isize, 1]);
+        println!("{}", col_vec);
     }
 }

--- a/mathoxide-lib/src/array.rs
+++ b/mathoxide-lib/src/array.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use num_traits::Num;
 
 use crate::formatter::{ArrayFormatter, VerboseFormatter};
-use crate::shape_utils::{self, ShapeDim};
+use crate::shape_utils::{infer_shape, ShapeDim};
 use crate::storage::Storage;
 use crate::views::{ArrayView, ContiguousView};
 
@@ -80,7 +80,7 @@ where
         ShapeDim: From<SizeType>,
         ListType: AsRef<[SizeType]>,
     {
-        let new_shape = shape_utils::infer_shape(shape, self.numel());
+        let new_shape = infer_shape(shape, self.numel()).expect("error while inferring shape");
         if new_shape.iter().product::<usize>() != self.numel() {
             panic!(
                 "{:?} not a valid shape for array of size {}",
@@ -111,20 +111,14 @@ mod test {
     #[test]
     fn reshape_2d_to_1d() {
         let array = Array::<ThreadSafeStorage<u32>, ContiguousView>::zeros(&[2, 3]);
-        // Temporary until getters for Array are available
-        println!("{}", array);
         let row_vec = array.reshape([6usize]);
-        println!("{}", row_vec);
+        assert_eq!(row_vec.shape(), &[6]);
     }
 
     #[test]
     fn reshape_2d_to_1d_inferred() {
         let array = Array::<ThreadSafeStorage<u32>, ContiguousView>::zeros(&[2, 3]);
-        // Temporary until getters for Array are available
-        println!("{}", array);
         let row_vec = array.reshape([-1isize]);
-        println!("{}", row_vec);
-        let col_vec = array.reshape([-1isize, 1]);
-        println!("{}", col_vec);
+        assert_eq!(row_vec.shape(), &[6]);
     }
 }

--- a/mathoxide-lib/src/lib.rs
+++ b/mathoxide-lib/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod array;
 mod formatter;
+mod shape_utils;
 mod storage;
 mod thread_safe_storage;
 mod thread_unsafe_storage;

--- a/mathoxide-lib/src/shape_utils.rs
+++ b/mathoxide-lib/src/shape_utils.rs
@@ -1,6 +1,6 @@
 pub enum ShapeDim {
     Known(usize),
-    Dyn,
+    Inferred,
 }
 
 impl From<isize> for ShapeDim {
@@ -8,7 +8,7 @@ impl From<isize> for ShapeDim {
         if val >= 0 {
             ShapeDim::Known(val as usize)
         } else {
-            ShapeDim::Dyn
+            ShapeDim::Inferred
         }
     }
 }
@@ -19,7 +19,16 @@ impl From<usize> for ShapeDim {
     }
 }
 
-fn parse<T, ListType>(shape: ListType) -> Vec<ShapeDim>
+impl ShapeDim {
+    fn unwrap_known(&self) -> Result<usize, &str> {
+        match *self {
+            ShapeDim::Known(u) => Ok(u),
+            ShapeDim::Inferred => Err("cannot unwrap inferred value"),
+        }
+    }
+}
+
+fn normalize_shape<T, ListType>(shape: ListType) -> Vec<ShapeDim>
 where
     T: Copy,
     ListType: AsRef<[T]>,
@@ -28,31 +37,53 @@ where
     shape.as_ref().iter().map(|x| ShapeDim::from(*x)).collect()
 }
 
-pub fn infer_shape<T, ListType>(shape: ListType, numel: usize) -> Vec<usize>
+pub fn infer_shape<T, ListType>(shape: ListType, numel: usize) -> Result<Vec<usize>, String>
 where
     T: Copy,
     ListType: AsRef<[T]>,
     ShapeDim: From<T>,
 {
-    let shape = parse(shape);
-    let n_dyn = shape.iter().filter(|x| matches!(x, ShapeDim::Dyn)).count();
-    if n_dyn > 1 {
-        panic!("only one dimension can be inferred");
+    let shape = normalize_shape(shape);
+
+    if shape.is_empty() {
+        return Err("shape cannot be empty".to_string());
     }
-    let product = shape
+
+    let n_dyn = shape
         .iter()
-        .map(|x| match *x {
-            ShapeDim::Known(u) => u,
-            ShapeDim::Dyn => 1,
-        })
-        .product::<usize>();
+        .filter(|x| matches!(x, ShapeDim::Inferred))
+        .count();
+
+    if n_dyn > 1 {
+        return Err("only one dimension can be inferred".to_string());
+    }
+    if n_dyn == 0 {
+        return Ok(shape
+            .iter()
+            .map(|x| x.unwrap_known().unwrap())
+            .collect::<Vec<usize>>());
+    }
+
+    let product: usize = shape
+        .iter()
+        .map(|x| x.unwrap_known().unwrap_or(1))
+        .product();
+
+    if product == 0 {
+        if numel == 0 {
+            return Err("unspecified dimension can be any value for tensor of size 0".to_string());
+        } else {
+            return Err("shape with 0-dimensions is not valid for non-empty tensors".to_string());
+        }
+    }
+
+    if numel % product != 0 {
+        return Err(format!("cannot infer shape with {} elements", numel));
+    }
     let inferred = numel / product;
 
-    shape
+    Ok(shape
         .iter()
-        .map(|x| match *x {
-            ShapeDim::Known(u) => u,
-            ShapeDim::Dyn => inferred,
-        })
-        .collect::<Vec<usize>>()
+        .map(|x| x.unwrap_known().unwrap_or(inferred))
+        .collect::<Vec<usize>>())
 }

--- a/mathoxide-lib/src/shape_utils.rs
+++ b/mathoxide-lib/src/shape_utils.rs
@@ -1,0 +1,58 @@
+pub enum ShapeDim {
+    Known(usize),
+    Dyn,
+}
+
+impl From<isize> for ShapeDim {
+    fn from(val: isize) -> Self {
+        if val >= 0 {
+            ShapeDim::Known(val as usize)
+        } else {
+            ShapeDim::Dyn
+        }
+    }
+}
+
+impl From<usize> for ShapeDim {
+    fn from(val: usize) -> Self {
+        ShapeDim::Known(val)
+    }
+}
+
+fn parse<T, ListType>(shape: ListType) -> Vec<ShapeDim>
+where
+    T: Copy,
+    ListType: AsRef<[T]>,
+    ShapeDim: From<T>,
+{
+    shape.as_ref().iter().map(|x| ShapeDim::from(*x)).collect()
+}
+
+pub fn infer_shape<T, ListType>(shape: ListType, numel: usize) -> Vec<usize>
+where
+    T: Copy,
+    ListType: AsRef<[T]>,
+    ShapeDim: From<T>,
+{
+    let shape = parse(shape);
+    let n_dyn = shape.iter().filter(|x| matches!(x, ShapeDim::Dyn)).count();
+    if n_dyn > 1 {
+        panic!("only one dimension can be inferred");
+    }
+    let product = shape
+        .iter()
+        .map(|x| match *x {
+            ShapeDim::Known(u) => u,
+            ShapeDim::Dyn => 1,
+        })
+        .product::<usize>();
+    let inferred = numel / product;
+
+    shape
+        .iter()
+        .map(|x| match *x {
+            ShapeDim::Known(u) => u,
+            ShapeDim::Dyn => inferred,
+        })
+        .collect::<Vec<usize>>()
+}

--- a/mathoxide-lib/src/storage.rs
+++ b/mathoxide-lib/src/storage.rs
@@ -6,7 +6,7 @@ use crate::thread_safe_storage::{
 };
 use crate::thread_unsafe_storage::ThreadUnsafeStorage;
 
-pub trait Storage: From<Vec<Self::Stored>> {
+pub trait Storage: From<Vec<Self::Stored>> + Clone {
     type Stored;
     type Guard<'a>: Deref<Target = [Self::Stored]>
     where
@@ -20,7 +20,7 @@ pub trait Storage: From<Vec<Self::Stored>> {
     fn storage_len(&self) -> Result<usize, &str>;
 }
 
-impl<T> Storage for ThreadSafeStorage<T> {
+impl<T: Clone> Storage for ThreadSafeStorage<T> {
     type Stored = T;
     type Guard<'a>
     where
@@ -44,7 +44,7 @@ impl<T> Storage for ThreadSafeStorage<T> {
     }
 }
 
-impl<T> Storage for ThreadUnsafeStorage<T> {
+impl<T: Clone> Storage for ThreadUnsafeStorage<T> {
     type Stored = T;
     type Guard<'a>
     where

--- a/mathoxide-lib/src/storage.rs
+++ b/mathoxide-lib/src/storage.rs
@@ -20,7 +20,7 @@ pub trait Storage: From<Vec<Self::Stored>> + Clone {
     fn storage_len(&self) -> Result<usize, &str>;
 }
 
-impl<T: Clone> Storage for ThreadSafeStorage<T> {
+impl<T> Storage for ThreadSafeStorage<T> {
     type Stored = T;
     type Guard<'a>
     where
@@ -44,7 +44,7 @@ impl<T: Clone> Storage for ThreadSafeStorage<T> {
     }
 }
 
-impl<T: Clone> Storage for ThreadUnsafeStorage<T> {
+impl<T> Storage for ThreadUnsafeStorage<T> {
     type Stored = T;
     type Guard<'a>
     where

--- a/mathoxide-lib/src/thread_safe_storage.rs
+++ b/mathoxide-lib/src/thread_safe_storage.rs
@@ -53,7 +53,6 @@ impl<'a, T> std::ops::DerefMut for ThreadSafeStorageGuardMut<'a, T> {
     }
 }
 
-#[derive(Clone)]
 pub(crate) struct ThreadSafeStorage<T> {
     data: Arc<Mutex<Vec<T>>>,
 }
@@ -88,6 +87,14 @@ impl<T> ThreadSafeStorage<T> {
 impl<T> From<Vec<T>> for ThreadSafeStorage<T> {
     fn from(val: Vec<T>) -> Self {
         ThreadSafeStorage::new(val)
+    }
+}
+
+impl<T> Clone for ThreadSafeStorage<T> {
+    fn clone(&self) -> Self {
+        Self {
+            data: Arc::clone(&self.data),
+        }
     }
 }
 

--- a/mathoxide-lib/src/thread_unsafe_storage.rs
+++ b/mathoxide-lib/src/thread_unsafe_storage.rs
@@ -1,7 +1,6 @@
 use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Rc;
 
-#[derive(Clone)]
 pub(crate) struct ThreadUnsafeStorage<T> {
     data: Rc<RefCell<Vec<T>>>,
 }
@@ -36,6 +35,14 @@ impl<T> ThreadUnsafeStorage<T> {
 impl<T> From<Vec<T>> for ThreadUnsafeStorage<T> {
     fn from(val: Vec<T>) -> Self {
         ThreadUnsafeStorage::new(val)
+    }
+}
+
+impl<T> Clone for ThreadUnsafeStorage<T> {
+    fn clone(&self) -> Self {
+        Self {
+            data: Rc::clone(&self.data),
+        }
     }
 }
 


### PR DESCRIPTION
Implements `reshape()` for arrays. Up to one unspecified dimension is allowed in which case it is automatically inferred at runtime. Arrays created using `reshape()` share the same storage as the original array.