### PR TITLE
Implement get() and item()

### DIFF
--- a/mathoxide-lib/src/array.rs
+++ b/mathoxide-lib/src/array.rs
@@ -64,14 +64,13 @@ where
         &self,
         idx: ListType,
     ) -> Array<StorageType, ContiguousView> {
-        let offset = match self.view.try_translate(&idx) {
-            Ok(u) => u,
-            Err(_) => panic!(
+        let offset = self.view.checked_translate(&idx).unwrap_or_else(|| {
+            panic!(
                 "Index {:?} is not valid for a view with shape {:?}",
                 idx.as_ref(),
                 self.shape()
-            ),
-        };
+            )
+        });
         let view = ContiguousView::new_with_offset([1], offset);
         Array {
             storage: self.storage.clone(),
@@ -151,6 +150,13 @@ mod test {
     fn item_panic() {
         let array = Array::<ThreadSafeStorage<u32>, ContiguousView>::zeros(&[4, 5]);
         let result = std::panic::catch_unwind(|| array.item());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_panic() {
+        let array = Array::<ThreadSafeStorage<u32>, ContiguousView>::zeros(&[4, 5]);
+        let result = std::panic::catch_unwind(|| array.get([4, 5]));
         assert!(result.is_err());
     }
 

--- a/mathoxide-lib/src/views.rs
+++ b/mathoxide-lib/src/views.rs
@@ -4,16 +4,16 @@ pub trait ArrayView {
     type IterType;
 
     fn translate<ListType: AsRef<[usize]>>(&self, idx: ListType) -> usize;
-    fn try_translate<ListType: AsRef<[usize]>>(&self, idx: ListType) -> Result<usize, &str> {
+    fn checked_translate<ListType: AsRef<[usize]>>(&self, idx: ListType) -> Option<usize> {
         let valid = idx
             .as_ref()
             .iter()
             .zip(self.shape().iter())
             .all(|(idx_i, shape_i)| idx_i < shape_i);
         if valid {
-            Ok(self.translate(idx))
+            Some(self.translate(idx))
         } else {
-            Err("invalid shape")
+            None
         }
     }
     fn offset(&self) -> usize;

--- a/mathoxide-lib/src/views.rs
+++ b/mathoxide-lib/src/views.rs
@@ -4,6 +4,18 @@ pub trait ArrayView {
     type IterType;
 
     fn translate<ListType: AsRef<[usize]>>(&self, idx: ListType) -> usize;
+    fn try_translate<ListType: AsRef<[usize]>>(&self, idx: ListType) -> Result<usize, &str> {
+        let valid = idx
+            .as_ref()
+            .iter()
+            .zip(self.shape().iter())
+            .all(|(idx_i, shape_i)| idx_i < shape_i);
+        if valid {
+            Ok(self.translate(idx))
+        } else {
+            Err("invalid shape")
+        }
+    }
     fn offset(&self) -> usize;
     fn shape(&self) -> &[usize];
     fn stride(&self) -> &[usize];

--- a/mathoxide-lib/src/views.rs
+++ b/mathoxide-lib/src/views.rs
@@ -10,11 +10,7 @@ pub trait ArrayView {
             .iter()
             .zip(self.shape().iter())
             .all(|(idx_i, shape_i)| idx_i < shape_i);
-        if valid {
-            Some(self.translate(idx))
-        } else {
-            None
-        }
+        valid.then(|| self.translate(idx))
     }
     fn offset(&self) -> usize;
     fn shape(&self) -> &[usize];


### PR DESCRIPTION
This is allows the user to get a view of a single element of an array. Furthermore, if the element type is clonable then the user can extract a copy of that item out of the array.

Closes #17 