### PR TITLE
Add utility method to iterate a shape by column

### DIFF
--- a/mathoxide-lib/src/lib.rs
+++ b/mathoxide-lib/src/lib.rs
@@ -9,3 +9,4 @@ mod thread_safe_storage;
 mod thread_unsafe_storage;
 mod view_iters;
 mod views;
+mod utils;

--- a/mathoxide-lib/src/utils.rs
+++ b/mathoxide-lib/src/utils.rs
@@ -1,0 +1,77 @@
+pub struct ByRowIterator {
+    shape: Vec<usize>,
+    current: usize,
+    numel: usize,
+}
+
+impl Iterator for ByRowIterator {
+    type Item = Vec<usize>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current >= self.numel {
+            None
+        } else {
+            let v = inverse_translate(self.current, &self.shape);
+            self.current += 1;
+            Some(v)
+        }
+    }
+}
+
+fn inverse_translate<Shape: AsRef<[usize]>>(idx: usize, shape: Shape) -> Vec<usize> {
+    shape.as_ref().iter().rev().scan((1, 0), |(divisor, remainder), e| {
+        let prev_div = *divisor;
+        *divisor *= e;
+        let res = ((idx - *remainder) % *divisor) / prev_div;
+        *remainder += res;
+        Some(res)
+    }).collect()
+}
+
+
+pub fn iterate_by_column<Shape: AsRef<[usize]>>(shape: &Shape) -> ByRowIterator {
+    ByRowIterator {
+        numel: shape.as_ref().iter().product(),
+        shape: shape.as_ref().clone().into(),
+        current: 0,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let mut count = 0;
+        for indices in iterate_by_column(&[1,1]) {
+            assert_eq!(indices.as_slice(), &[0,0]);
+            count += 1;
+        }
+
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn returns_correct_indices() {
+        let mut iterator = iterate_by_column(&[2, 3, 4, 17]);
+
+        for l in 0..2 {
+            for k in 0..3 {
+                for j in 0..4 {
+                    for i in 0..17 {
+                        let res = iterator.next().unwrap();
+                        assert_eq!(res.as_slice(), &[i, j, k, l]);
+                    }
+                }
+            }
+        }
+
+        assert!(iterator.next().is_none());
+    }
+
+    #[test]
+    fn accepts_run_time_indices() {
+        let _iterator = iterate_by_column(&vec![2,3,4,17]);
+    }
+}

--- a/mathoxide-lib/src/utils.rs
+++ b/mathoxide-lib/src/utils.rs
@@ -34,17 +34,11 @@ impl<'a> IndexIteration<'a>
         }
     }
 
-    pub fn by_column<Shape>(shape: &'a Shape) -> Self
+    pub fn row_major<Shape>(shape: &'a Shape) -> Self
     where
         Shape: AsRef<[usize]>,
     {
-        let shape = shape.as_ref();
-        Self {
-            shape,
-            index: vec![0; shape.len()],
-            state: IndexState::NotStarted,
-            updater: update_index_by_column,
-        }
+            Self::new(shape, update_index_row_major)
     }
 
     pub fn next<'b>(&'b mut self) -> Option<&'b [usize]>
@@ -69,7 +63,7 @@ impl<'a> IndexIteration<'a>
     }
 }
 
-pub fn update_index_by_column<Shape: AsRef<[usize]> +?Sized >(index: &mut Vec<usize>, shape: &Shape) -> UpdaterResult {
+pub fn update_index_row_major<Shape: AsRef<[usize]> +?Sized >(index: &mut Vec<usize>, shape: &Shape) -> UpdaterResult {
     let shape = shape.as_ref();
 
     let ndim = shape.len();
@@ -98,7 +92,7 @@ mod test {
     fn update_by_column_simple_test() {
         let mut index = vec![0, 0];
         let mut count = 0;
-        while let UpdaterResult::NotDone = update_index_by_column(&mut index, &[1,1]) {
+        while let UpdaterResult::NotDone = update_index_row_major(&mut index, &[1,1]) {
             assert_eq!(index.as_slice(), &[0,0]);
             count += 1;
         }
@@ -115,7 +109,7 @@ mod test {
                 for k in 0..4 {
                     for l in 0..17 {
                         assert_eq!(index.as_slice(), &[i, j, k, l]);
-                        if let UpdaterResult::Done = update_index_by_column(&mut index, &[2, 3, 4, 17]) {
+                        if let UpdaterResult::Done = update_index_row_major(&mut index, &[2, 3, 4, 17]) {
                             break;
                         }
                     }
@@ -128,7 +122,7 @@ mod test {
   
     #[test]
     fn by_column_iteration_wrapper_exhaustive() {
-        let mut index_wrapper = IndexIteration::by_column(&[2,3,4,17]);
+        let mut index_wrapper = IndexIteration::row_major(&[2,3,4,17]);
         for i in 0..2 {
             for j in 0..3 {
                 for k in 0..4 {
@@ -145,7 +139,7 @@ mod test {
 
     #[test]
     fn by_column_iteration_wrapper_no_more() {
-        let mut index_wrapper = IndexIteration::by_column(&[2,3,4,17]);
+        let mut index_wrapper = IndexIteration::row_major(&[2,3,4,17]);
         let mut count = 0;
         while let Some(_) = index_wrapper.next() {
             count += 1;


### PR DESCRIPTION
Sometimes it is required that we iterate over the same elements of different
arrays. An example of this is pointwise operations where the views of
the two operands might be different, and we can't simply use the same index
on the underlying storages.

This PR is needed to resolve #2 